### PR TITLE
Add custom tags for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ variable "single_nat_gateway" {
 
 To use a single NAT gateway, set `multi_az_nat_gateway = 0` and `single_nat_gateway = 1` in `terraform.tfvars`
 
+### Tagging
+
+The subnets created can include custom tags by setting variables of the form `SUBNETNAME_subnet_tags`.
+
+| Subnet          | Variable                    |
+| --------------- | --------------------------- |
+| admin           | admin_subnet_tags           |
+| public          | public_subnet_tags          |
+| private_prod    | private_prod_subnet_tags    |
+| private_working | private_working_subnet_tags |
+
 ## Testing
 
 This repo contains a few `.tfvars.example` files in the root illustrating different module usage configuration patterns. Each `.tfvars.example` file has a corresponding tfplan output file under `test/fixtures` representing the expected output. The project Makefile includes targets for installing a specific version of Terraform and comparing results of a `terraform plan` against expected output files.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ az_count = 4
 
 `multi_az_nat_gateway`
 
-Ideally, in a multi-AZ setup, there is at least one NAT Gateway residing in each availability zone.  This allows the outbound traffic from private subnets in each AZ to function independently, and allow for some resiliance in-case of an AZ outage.
+Ideally, in a multi-AZ setup, there is at least one NAT Gateway residing in each availability zone.  This allows the outbound traffic from private subnets in each AZ to function independently, and allow for some resilience in-case of an AZ outage.
 
 `single_nat_gateway`
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The routing tables can include custom tags by setting variables of the form `TAB
 | public      | public_route_table_tags  |
 | private     | private_route_table_tags |
 
+The internet gateway can be tagged with the variable `internet_gateway_tags`
+
 ## Testing
 
 This repo contains a few `.tfvars.example` files in the root illustrating different module usage configuration patterns. Each `.tfvars.example` file has a corresponding tfplan output file under `test/fixtures` representing the expected output. The project Makefile includes targets for installing a specific version of Terraform and comparing results of a `terraform plan` against expected output files.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ The subnets created can include custom tags by setting variables of the form `SU
 | private_prod    | private_prod_subnet_tags    |
 | private_working | private_working_subnet_tags |
 
+The routing tables can include custom tags by setting variables of the form `TABLENAME_route_table_tags`.
+
+| Route Table | Variable                 |
+| ----------- | ------------------------ |
+| public      | public_route_table_tags  |
+| private     | private_route_table_tags |
+
 ## Testing
 
 This repo contains a few `.tfvars.example` files in the root illustrating different module usage configuration patterns. Each `.tfvars.example` file has a corresponding tfplan output file under `test/fixtures` representing the expected output. The project Makefile includes targets for installing a specific version of Terraform and comparing results of a `terraform plan` against expected output files.

--- a/internet-gateway.tf
+++ b/internet-gateway.tf
@@ -1,4 +1,7 @@
 resource "aws_internet_gateway" "default" {
   vpc_id = "${aws_vpc.default.id}"
-  tags = "${merge(var.global_tags, map("Name", "${var.aws_vpc_name}"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "${var.aws_vpc_name}"),
+                  var.internet_gateway_tags)}"
+
 }

--- a/route-table.tf
+++ b/route-table.tf
@@ -1,7 +1,9 @@
 # Routing table for public subnets
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.default.id}"
-  tags = "${merge(var.global_tags, map("Name", "public"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "public"),
+                  var.public_route_table_tags)}"
 }
 
 output "aws_route_table_public_ids" {
@@ -19,7 +21,9 @@ resource "aws_route" "public_internet_gateway" {
 resource "aws_route_table" "private" {
   count = "${((var.multi_az_nat_gateway * var.az_count) + (var.single_nat_gateway * 1))}"
   vpc_id = "${aws_vpc.default.id}"
-  tags = "${merge(var.global_tags, map("Name", "private_az${(count.index +1)}"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "private_az${(count.index +1)}"),
+                  var.private_route_table_tags)}"
 }
 
 output "aws_route_table_private_ids" {

--- a/subnets.tf
+++ b/subnets.tf
@@ -7,7 +7,9 @@ resource "aws_subnet" "admin" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "${var.vpc_cidr_base}${lookup(var.admin_subnet_cidrs, format("zone%d", count.index))}"
   availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags, map("Name", "admin_az${(count.index +1)}"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "admin_az${(count.index +1)}"),
+                  var.admin_subnet_tags)}"
 }
 
 output "aws_subnet_admin_ids" {
@@ -25,7 +27,9 @@ resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "${var.vpc_cidr_base}${lookup(var.public_subnet_cidrs, format("zone%d", count.index))}"
   availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags, map("Name", "public_az${(count.index +1)}"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "public_az${(count.index +1)}"),
+                  var.public_subnet_tags)}"
 }
 
 output "aws_subnet_public_ids" {
@@ -43,7 +47,9 @@ resource "aws_subnet" "private_prod" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "${var.vpc_cidr_base}${lookup(var.private_prod_subnet_cidrs, format("zone%d", count.index))}"
   availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags, map("Name", "private_prod_az${(count.index +1)}"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "private_prod_az${(count.index +1)}"),
+                  var.private_prod_subnet_tags)}"
 }
 
 output "aws_subnet_private_prod_ids" {
@@ -61,7 +67,9 @@ resource "aws_subnet" "private_working" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "${var.vpc_cidr_base}${lookup(var.private_working_subnet_cidrs, format("zone%d", count.index))}"
   availability_zone = "${element(split(", ", var.aws_azs), count.index)}"
-  tags = "${merge(var.global_tags, map("Name", "private_working_az${(count.index +1)}"))}"
+  tags = "${merge(var.global_tags,
+                  map("Name", "private_working_az${(count.index +1)}"),
+                  var.private_working_subnet_tags)}"
 }
 
 output "aws_subnet_private_working_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,11 @@ variable "admin_subnet_cidrs" {
   }
 }
 
+variable "admin_subnet_tags" {
+  description = "Tags to apply to the admin subnet"
+  default = {}
+}
+
 variable "public_subnet_parent_cidr" {
   description = "parent CIDR for the public subnets"
   default = ".32.0/19"
@@ -65,6 +70,11 @@ variable "public_subnet_cidrs" {
     zone2 = ".48.0/21"
     zone3 = ".56.0/21"
   }
+}
+
+variable "public_subnet_tags" {
+  description = "Tags to apply to the public subnets"
+  default = {}
 }
 
 variable "private_prod_subnet_parent_cidr" {
@@ -82,6 +92,11 @@ variable "private_prod_subnet_cidrs" {
   }
 }
 
+variable "private_prod_subnet_tags" {
+  description = "Tags to apply to the private production subnets"
+  default = {}
+}
+
 variable "private_working_subnet_parent_cidr" {
   description = "parent CIDR for the private working subnets"
   default = ".96.0/19"
@@ -95,6 +110,11 @@ variable "private_working_subnet_cidrs" {
     zone2 = ".112.0/21"
     zone3 = ".120.0/21"
   }
+}
+
+variable "private_working_subnet_tags" {
+  description = "Tags to apply to the private working subnets"
+  default = {}
 }
 
 variable "multi_az_nat_gateway" {

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,16 @@ variable "single_nat_gateway" {
   default = 0
 }
 
+variable "public_route_table_tags" {
+  description = "Tags to apply to the public route table"
+  default = {}
+}
+
+variable "private_route_table_tags" {
+  description = "Tags to apply to the private route table"
+  default = {}
+}
+
 variable "global_tags" {
   description = "AWS tags that will be added to all resources managed herein"
   type = "map"

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,11 @@ variable "single_nat_gateway" {
   default = 0
 }
 
+variable "internet_gateway_tags" {
+  description = "Tags to apply to the internet gateway"
+  default = {}
+}
+
 variable "public_route_table_tags" {
   description = "Tags to apply to the public route table"
   default = {}


### PR DESCRIPTION
Add support for user-defined tags on the resources created. This will allow us to prevent subsequent TF runs to remove tags needed by Kubernetes without having to ignore resources. 

@reactiveops/technical-team-members 