### PR TITLE
Ignoring tags

### DIFF
--- a/nat-gateway.tf
+++ b/nat-gateway.tf
@@ -17,6 +17,9 @@ resource "aws_nat_gateway" "nat_gateway" {
   subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
   allocation_id = "${element(aws_eip.mod_nat.*.id, count.index)}"
   depends_on = ["aws_internet_gateway.default","aws_eip.mod_nat","aws_subnet.public"]
+  lifecycle = {
+                ignore_changes = ["tags"]
+              }
 }
 
 output "aws_nat_gateway_count" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -19,6 +19,9 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = "${var.vpc_enable_dns_hostnames}"
   enable_classiclink = "${var.vpc_enable_classiclink}"
   tags = "${merge(var.global_tags, map("Name", "${var.aws_vpc_name}"))}"
+  lifecycle = { 
+                ignore_changes = ["tags"]
+              }
 }
 
 output "aws_vpc_id" {


### PR DESCRIPTION
Recent changes in kops have it putting shared tags on the vpc and the nat gateways. Its difficult to add those to the terraform because the tag key is the name of the cluster. Instead of changing those on each run, I'm setting it to ignore changes on tags after creation and letting kops do its thing