### PR TITLE
Add s3 endpoint routes for provided additional route tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Considerations when enabling:
 * **ENABLING WILL DISRUPT CONNECTIONS** When initially enabling this any inflight S3 connections in the VPC [will be interrupted](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-s3.html).
 * [DNS resolution must be enabled for the VPC].(https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html#vpc-endpoints-limitations)
 
+#### Additional Route Table Routes
+
+By default when enabled all private subnet route tables will get a route for the S3 endpoint. You can pass additional route table ids for additional routes to be created. This is useful for route tables managed by Kops for example.
+
 #### Endpoint S3 policy
 
 Each endpoint has an associated IAM style policy attached. This module's default policy allows all access but can be overriden via TF variable `s3_vpc_endpoint_policy`. S3 bucket and IAM policies still apply. The endpoint policy is an additional limitation for connections through the endpoint.

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,12 @@ variable "s3_vpc_endpoint_policy" {
 POLICY
 }
 
+variable "s3_vpc_endpoint_route_table_ids" {
+  description = "By default routes to the s3 endpoint are added for private subnet route tables. Pass additional route table ids that require routes."
+  type = "list"
+  default = []
+}
+
 variable "internet_gateway_tags" {
   description = "Tags to apply to the internet gateway"
   default = {}

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -13,9 +13,9 @@
 #limitations under the License.
 
 resource "aws_vpc_endpoint" "s3_endpoint" {
-    count = "${var.enable_s3_vpc_endpoint ? 1 : 0}"
-    vpc_id = "${aws_vpc.default.id}"
-    service_name = "com.amazonaws.${var.aws_region}.s3"
-    route_table_ids = ["${aws_route_table.private.*.id}"]
-    policy = "${var.s3_vpc_endpoint_policy}"
+  count = "${var.enable_s3_vpc_endpoint ? 1 : 0}"
+  vpc_id = "${aws_vpc.default.id}"
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+  route_table_ids = ["${concat(aws_route_table.private.*.id, var.s3_vpc_endpoint_route_table_ids)}"]
+  policy = "${var.s3_vpc_endpoint_policy}"
 }


### PR DESCRIPTION
Allows for additional route tables to be provided for S3 endpoint routes. This is useful for adding routes to route tables managed by Kops. Kops doesn't offer any mechanism for custom routes.