### PR TITLE
Add a more flexible aws-vpc module

### DIFF
--- a/modules/single-cluster/README.md
+++ b/modules/single-cluster/README.md
@@ -5,14 +5,12 @@ This module builds the standard set of VPC subnets we implement for a cluster. T
 This module supports any size subnet from a `/16` to `/21`. It will take the input CIDR notation space and divide it evenly to create the desired subnets. The resulting subnets do have some unused space left over but the amount of IPs vary depending on the side of the super-net (CIDR) you provide.
 
 ## Known Issues
-- Module only builds in 3 availability zones:  
-  This module only supports spanning 3 AZs, and can not be expanded to 4 or reduced to 2 AZs.
 - Lowest subnet support is a `/21` CIDR range
-- Terraform `count` and Subnets:  
-  Creating subnets, and other assets, with Terraform's `count` function could lead to issues refactoring this module in the future, and the same problem exists with the original module.
+- Cannot migrate to more or less AZs. If you change AZs at ALL it will break everything. 
 
 # TODO
 1. Refactor the use of count
 1. Support enabling and disabling "subnet" sets: ie: I don't want to deploy the admin subnet, for example.
-1. Check user input on string fields or arrays
-1. Support more or less availability zones (eg. 1, 2 or 4)
+
+## Usage
+Need to be used in conjunction with a subnet CIDR generator module (provided).

--- a/modules/single-cluster/README.md
+++ b/modules/single-cluster/README.md
@@ -1,0 +1,18 @@
+# Single Cluster VPC Builder
+This module builds the standard set of VPC subnets we implement for a cluster. This includes VPCs for adjacent services as well as utility and bastion subnets. This module supports a VPC for provisioning _only one cluster_. Previous modules supported building a production and non-prod cluster in the same VPC but with different subnets. This module is intended to support a single prod _or_ non-prod cluster.
+
+## Dynamic Aspects
+This module supports any size subnet from a `/16` to `/21`. It will take the input CIDR notation space and divide it evenly to create the desired subnets. The resulting subnets do have some unused space left over but the amount of IPs vary depending on the side of the super-net (CIDR) you provide.
+
+## Known Issues
+- Module only builds in 3 availability zones:  
+  This module only supports spanning 3 AZs, and can not be expanded to 4 or reduced to 2 AZs.
+- Lowest subnet support is a `/21` CIDR range
+- Terraform `count` and Subnets:  
+  Creating subnets, and other assets, with Terraform's `count` function could lead to issues refactoring this module in the future, and the same problem exists with the original module.
+
+# TODO
+1. Refactor the use of count
+1. Support enabling and disabling "subnet" sets: ie: I don't want to deploy the admin subnet, for example.
+1. Check user input on string fields or arrays
+1. Support more or less availability zones (eg. 1, 2 or 4)

--- a/modules/single-cluster/dynamics.tf
+++ b/modules/single-cluster/dynamics.tf
@@ -1,0 +1,44 @@
+# Dynamics house all the CIDR and other dynamic elements of this module
+
+locals {
+  _supernet_one   = "${cidrsubnet(var.vpc_cidr, 2, 0)}"
+  _supernet_two   = "${cidrsubnet(var.vpc_cidr, 2, 1)}"
+  _supernet_three = "${cidrsubnet(var.vpc_cidr, 2, 2)}"
+  _supernet_four  = "${cidrsubnet(var.vpc_cidr, 2, 3)}"
+
+  public_cidr_subnets = [
+    "${cidrsubnet(local._supernet_one, 2, 0)}",
+    "${cidrsubnet(local._supernet_one, 2, 1)}",
+    "${cidrsubnet(local._supernet_one, 2, 2)}",
+  ]
+
+  private_cidr_subnets = [
+    "${cidrsubnet(local._supernet_one, 2, 3)}",
+    "${cidrsubnet(local._supernet_two, 2, 0)}",
+    "${cidrsubnet(local._supernet_two, 2, 1)}",
+  ]
+
+  admin_cidr_subnets = [
+    "${cidrsubnet(local._supernet_two, 2, 2)}",
+    "${cidrsubnet(local._supernet_two, 2, 3)}",
+    "${cidrsubnet(local._supernet_three, 2, 0)}",
+  ]
+
+  kops_subnets = {
+    node_cidr_one      = "${cidrsubnet(local._supernet_three, 2, 1)}"
+    node_cidr_two      = "${cidrsubnet(local._supernet_three, 2, 2)}"
+    node_cidr_three    = "${cidrsubnet(local._supernet_three, 2, 3)}"
+    utility_cidr_one   = "${cidrsubnet(local._supernet_four, 2, 0)}"
+    utility_cidr_two   = "${cidrsubnet(local._supernet_four, 2, 1)}"
+    utility_cidr_three = "${cidrsubnet(local._supernet_four, 2, 2)}"
+  }
+}
+
+output "supernets" {
+  value = [
+    "${local._supernet_one}",
+    "${local._supernet_two}",
+    "${local._supernet_three}",
+    "${local._supernet_four}",
+  ]
+}

--- a/modules/single-cluster/dynamics.tf
+++ b/modules/single-cluster/dynamics.tf
@@ -1,44 +1,7 @@
 # Dynamics house all the CIDR and other dynamic elements of this module
 
 locals {
-  _supernet_one   = "${cidrsubnet(var.vpc_cidr, 2, 0)}"
-  _supernet_two   = "${cidrsubnet(var.vpc_cidr, 2, 1)}"
-  _supernet_three = "${cidrsubnet(var.vpc_cidr, 2, 2)}"
-  _supernet_four  = "${cidrsubnet(var.vpc_cidr, 2, 3)}"
-
-  public_cidr_subnets = [
-    "${cidrsubnet(local._supernet_one, 2, 0)}",
-    "${cidrsubnet(local._supernet_one, 2, 1)}",
-    "${cidrsubnet(local._supernet_one, 2, 2)}",
-  ]
-
-  private_cidr_subnets = [
-    "${cidrsubnet(local._supernet_one, 2, 3)}",
-    "${cidrsubnet(local._supernet_two, 2, 0)}",
-    "${cidrsubnet(local._supernet_two, 2, 1)}",
-  ]
-
-  admin_cidr_subnets = [
-    "${cidrsubnet(local._supernet_two, 2, 2)}",
-    "${cidrsubnet(local._supernet_two, 2, 3)}",
-    "${cidrsubnet(local._supernet_three, 2, 0)}",
-  ]
-
-  kops_subnets = {
-    node_cidr_one      = "${cidrsubnet(local._supernet_three, 2, 1)}"
-    node_cidr_two      = "${cidrsubnet(local._supernet_three, 2, 2)}"
-    node_cidr_three    = "${cidrsubnet(local._supernet_three, 2, 3)}"
-    utility_cidr_one   = "${cidrsubnet(local._supernet_four, 2, 0)}"
-    utility_cidr_two   = "${cidrsubnet(local._supernet_four, 2, 1)}"
-    utility_cidr_three = "${cidrsubnet(local._supernet_four, 2, 2)}"
-  }
-}
-
-output "supernets" {
-  value = [
-    "${local._supernet_one}",
-    "${local._supernet_two}",
-    "${local._supernet_three}",
-    "${local._supernet_four}",
-  ]
+  public_cidr_subnets  = ["${var.public_subnets_list}"]
+  private_cidr_subnets = ["${var.private_subnets_list}"]
+  admin_cidr_subnets   = ["${var.admin_subnets_list}"]
 }

--- a/modules/single-cluster/four-availability-zones/subnets.tf
+++ b/modules/single-cluster/four-availability-zones/subnets.tf
@@ -1,0 +1,67 @@
+# Dynamics house all the CIDR and other dynamic elements of this module
+
+variable "base_cidr" {}
+
+locals {
+  _kops_reserved = "${cidrsubnet(var.base_cidr, 1, 0)}"
+  _ops_based     = "${cidrsubnet(var.base_cidr, 1, 1)}"
+
+  public_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 4, 0)}",
+    "${cidrsubnet(local._ops_based, 4, 1)}",
+    "${cidrsubnet(local._ops_based, 4, 2)}",
+    "${cidrsubnet(local._ops_based, 4, 3)}",
+  ]
+
+  private_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 4, 4)}",
+    "${cidrsubnet(local._ops_based, 4, 5)}",
+    "${cidrsubnet(local._ops_based, 4, 6)}",
+    "${cidrsubnet(local._ops_based, 4, 7)}",
+  ]
+
+  admin_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 4, 8)}",
+    "${cidrsubnet(local._ops_based, 4, 9)}",
+    "${cidrsubnet(local._ops_based, 4, 10)}",
+    "${cidrsubnet(local._ops_based, 4, 11)}",
+  ]
+
+  kops_subnets = {
+    node_cidr_1    = "${cidrsubnet(local._kops_reserved, 3, 0)}"
+    node_cidr_2    = "${cidrsubnet(local._kops_reserved, 3, 1)}"
+    node_cidr_3    = "${cidrsubnet(local._kops_reserved, 3, 2)}"
+    node_cidr_4    = "${cidrsubnet(local._kops_reserved, 3, 3)}"
+    utility_cidr_1 = "${cidrsubnet(local._kops_reserved, 3, 4)}"
+    utility_cidr_2 = "${cidrsubnet(local._kops_reserved, 3, 5)}"
+    utility_cidr_3 = "${cidrsubnet(local._kops_reserved, 3, 6)}"
+    utility_cidr_4 = "${cidrsubnet(local._kops_reserved, 3, 7)}"
+  }
+}
+
+output "entire_network" {
+  value = "${var.base_cidr}"
+}
+
+output "supernets" {
+  value = {
+    OpsNetwork  = "${local._ops_based}"
+    KopsNetwork = "${local._kops_reserved}"
+  }
+}
+
+output "public_cidrs" {
+  value = ["${local.public_cidr_subnets}"]
+}
+
+output "private_cidrs" {
+  value = ["${local.private_cidr_subnets}"]
+}
+
+output "admin_cidrs" {
+  value = ["${local.admin_cidr_subnets}"]
+}
+
+output "kops_cidrs" {
+  value = "${local.kops_subnets}"
+}

--- a/modules/single-cluster/outputs.tf
+++ b/modules/single-cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "provisioned_cidrs" {
+  value = {
+    public_cidr_subnets  = "${local.public_cidr_subnets}"
+    private_cidr_subnets = "${local.private_cidr_subnets}"
+    admin_cidr_subnets   = "${local.admin_cidr_subnets}"
+  }
+}
+
+output "cidrs_for_kops" {
+  value = "${local.kops_subnets}"
+}

--- a/modules/single-cluster/outputs.tf
+++ b/modules/single-cluster/outputs.tf
@@ -5,7 +5,3 @@ output "provisioned_cidrs" {
     admin_cidr_subnets   = "${local.admin_cidr_subnets}"
   }
 }
-
-output "cidrs_for_kops" {
-  value = "${local.kops_subnets}"
-}

--- a/modules/single-cluster/subnet.tf
+++ b/modules/single-cluster/subnet.tf
@@ -1,7 +1,7 @@
 # Subnet creation
 ## Admin
 resource "aws_subnet" "admin" {
-  count             = 3
+  count             = "${local._count_of_availability_zones}"
   vpc_id            = "${aws_vpc.kube_vpc.id}"
   cidr_block        = "${local.admin_cidr_subnets[count.index]}"
   availability_zone = "${local.avail_zones_list[count.index]}"
@@ -13,14 +13,14 @@ output "aws_subnet_admin_ids" {
 }
 
 resource "aws_route_table_association" "admin" {
-  count          = 3
+  count          = "${local._count_of_availability_zones}"
   subnet_id      = "${element(aws_subnet.admin.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
 }
 
 ## Public
 resource "aws_subnet" "public" {
-  count             = 3
+  count             = "${local._count_of_availability_zones}"
   vpc_id            = "${aws_vpc.kube_vpc.id}"
   cidr_block        = "${local.public_cidr_subnets[count.index]}"
   availability_zone = "${local.avail_zones_list[count.index]}"
@@ -32,14 +32,14 @@ output "aws_subnet_public_ids" {
 }
 
 resource "aws_route_table_association" "public" {
-  count          = 3
+  count          = "${local._count_of_availability_zones}"
   subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
   route_table_id = "${aws_route_table.public.id}"
 }
 
 ## Private
 resource "aws_subnet" "private" {
-  count             = 3
+  count             = "${local._count_of_availability_zones}"
   vpc_id            = "${aws_vpc.kube_vpc.id}"
   cidr_block        = "${local.private_cidr_subnets[count.index]}"
   availability_zone = "${local.avail_zones_list[count.index]}"
@@ -51,7 +51,7 @@ output "aws_subnet_private_ids" {
 }
 
 resource "aws_route_table_association" "private" {
-  count          = 3
+  count          = "${local._count_of_availability_zones}"
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
 }

--- a/modules/single-cluster/subnet.tf
+++ b/modules/single-cluster/subnet.tf
@@ -1,0 +1,57 @@
+# Subnet creation
+## Admin
+resource "aws_subnet" "admin" {
+  count             = 3
+  vpc_id            = "${aws_vpc.kube_vpc.id}"
+  cidr_block        = "${local.admin_cidr_subnets[count.index]}"
+  availability_zone = "${local.avail_zones_list[count.index]}"
+  tags              = "${merge(local.tags, map("Name", "Admin Subnet"))}"
+}
+
+output "aws_subnet_admin_ids" {
+  value = ["${aws_subnet.admin.*.id}"]
+}
+
+resource "aws_route_table_association" "admin" {
+  count          = 3
+  subnet_id      = "${element(aws_subnet.admin.*.id, count.index)}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+}
+
+## Public
+resource "aws_subnet" "public" {
+  count             = 3
+  vpc_id            = "${aws_vpc.kube_vpc.id}"
+  cidr_block        = "${local.public_cidr_subnets[count.index]}"
+  availability_zone = "${local.avail_zones_list[count.index]}"
+  tags              = "${merge(local.tags, map("Name", "Public Subnet"))}"
+}
+
+output "aws_subnet_public_ids" {
+  value = ["${aws_subnet.public.*.id}"]
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 3
+  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+  route_table_id = "${aws_route_table.public.id}"
+}
+
+## Private
+resource "aws_subnet" "private" {
+  count             = 3
+  vpc_id            = "${aws_vpc.kube_vpc.id}"
+  cidr_block        = "${local.private_cidr_subnets[count.index]}"
+  availability_zone = "${local.avail_zones_list[count.index]}"
+  tags              = "${merge(local.tags, map("Name", "Private Subnet"))}"
+}
+
+output "aws_subnet_private_ids" {
+  value = ["${aws_subnet.private.*.id}"]
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 3
+  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+}

--- a/modules/single-cluster/three-availability-zones/subnets.tf
+++ b/modules/single-cluster/three-availability-zones/subnets.tf
@@ -1,0 +1,62 @@
+# Dynamics house all the CIDR and other dynamic elements of this module
+
+variable "base_cidr" {}
+
+locals {
+  _kops_reserved = "${cidrsubnet(var.base_cidr, 1, 0)}"
+  _ops_based     = "${cidrsubnet(var.base_cidr, 1, 1)}"
+
+  public_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 4, 0)}",
+    "${cidrsubnet(local._ops_based, 4, 1)}",
+    "${cidrsubnet(local._ops_based, 4, 2)}",
+  ]
+
+  private_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 4, 3)}",
+    "${cidrsubnet(local._ops_based, 4, 4)}",
+    "${cidrsubnet(local._ops_based, 4, 5)}",
+  ]
+
+  admin_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 4, 6)}",
+    "${cidrsubnet(local._ops_based, 4, 7)}",
+    "${cidrsubnet(local._ops_based, 4, 8)}",
+  ]
+
+  kops_subnets = {
+    node_cidr_1    = "${cidrsubnet(local._kops_reserved, 3, 0)}"
+    node_cidr_2    = "${cidrsubnet(local._kops_reserved, 3, 1)}"
+    node_cidr_3    = "${cidrsubnet(local._kops_reserved, 3, 2)}"
+    utility_cidr_1 = "${cidrsubnet(local._kops_reserved, 3, 3)}"
+    utility_cidr_2 = "${cidrsubnet(local._kops_reserved, 3, 4)}"
+    utility_cidr_3 = "${cidrsubnet(local._kops_reserved, 3, 5)}"
+  }
+}
+
+output "entire_network" {
+  value = "${var.base_cidr}"
+}
+
+output "supernets" {
+  value = {
+    OpsNetwork  = "${local._ops_based}"
+    KopsNetwork = "${local._kops_reserved}"
+  }
+}
+
+output "public_cidrs" {
+  value = ["${local.public_cidr_subnets}"]
+}
+
+output "private_cidrs" {
+  value = ["${local.private_cidr_subnets}"]
+}
+
+output "admin_cidrs" {
+  value = ["${local.admin_cidr_subnets}"]
+}
+
+output "kops_cidrs" {
+  value = "${local.kops_subnets}"
+}

--- a/modules/single-cluster/two-availability-zones/subnets.tf
+++ b/modules/single-cluster/two-availability-zones/subnets.tf
@@ -1,0 +1,57 @@
+# Dynamics house all the CIDR and other dynamic elements of this module
+
+variable "base_cidr" {}
+
+locals {
+  _kops_reserved = "${cidrsubnet(var.base_cidr, 1, 0)}"
+  _ops_based     = "${cidrsubnet(var.base_cidr, 1, 1)}"
+
+  public_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 3, 0)}",
+    "${cidrsubnet(local._ops_based, 3, 1)}",
+  ]
+
+  private_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 3, 2)}",
+    "${cidrsubnet(local._ops_based, 3, 3)}",
+  ]
+
+  admin_cidr_subnets = [
+    "${cidrsubnet(local._ops_based, 3, 4)}",
+    "${cidrsubnet(local._ops_based, 3, 5)}",
+  ]
+
+  kops_subnets = {
+    node_cidr_1    = "${cidrsubnet(local._kops_reserved, 2, 0)}"
+    node_cidr_2    = "${cidrsubnet(local._kops_reserved, 2, 1)}"
+    utility_cidr_1 = "${cidrsubnet(local._kops_reserved, 2, 2)}"
+    utility_cidr_2 = "${cidrsubnet(local._kops_reserved, 2, 3)}"
+  }
+}
+
+output "entire_network" {
+  value = "${var.base_cidr}"
+}
+
+output "supernets" {
+  value = {
+    OpsNetwork  = "${local._ops_based}"
+    KopsNetwork = "${local._kops_reserved}"
+  }
+}
+
+output "public_cidrs" {
+  value = ["${local.public_cidr_subnets}"]
+}
+
+output "private_cidrs" {
+  value = ["${local.private_cidr_subnets}"]
+}
+
+output "admin_cidrs" {
+  value = ["${local.admin_cidr_subnets}"]
+}
+
+output "kops_cidrs" {
+  value = "${local.kops_subnets}"
+}

--- a/modules/single-cluster/variables.tf
+++ b/modules/single-cluster/variables.tf
@@ -55,7 +55,7 @@ variable "extra_tags" {
 locals {
   default_tags = {
     "ManagedVia" = "Terraform"
-    "Author"     = "ReactiveOps"
+    "Author"     = "Fairwinds"
   }
 
   tags             = "${merge(local.default_tags, var.extra_tags)}"

--- a/modules/single-cluster/variables.tf
+++ b/modules/single-cluster/variables.tf
@@ -1,0 +1,49 @@
+# Required Variables
+
+variable "vpc_cidr" {
+  description = "The base CIDR that all subnets and vpcs will be created from. (Format 1.2.3.4/6)"
+}
+
+variable "vpc_name" {
+  description = "The name tag of the VPC you are creating."
+}
+
+variable "availability_zones" {
+  description = "The available zones, that matches the terraform provider you are using, for the VPC subnets and Nat Gateways. Format (us-west-2a,us-west-2b)"
+}
+
+# Optional Variables
+## Exposed VPC Settings
+variable "vpc_instance_tenancy" {
+  default = "default"
+}
+
+variable "vpc_enable_dns_support" {
+  default = "true"
+}
+
+variable "vpc_enable_dns_hostnames" {
+  default = "true"
+}
+
+variable "vpc_enable_classiclink" {
+  default = "false"
+}
+
+## Tagging Settings
+variable "extra_tags" {
+  type        = "map"
+  description = "Map of tags to apply in addition to already predefined tags of the module."
+  default     = {}
+}
+
+# Local Vars
+locals {
+  default_tags = {
+    "ManagedVia" = "Terraform"
+    "Author"     = "ReactiveOps"
+  }
+
+  tags             = "${merge(local.default_tags, var.extra_tags)}"
+  avail_zones_list = "${split(",", var.availability_zones)}"
+}

--- a/modules/single-cluster/variables.tf
+++ b/modules/single-cluster/variables.tf
@@ -1,7 +1,21 @@
 # Required Variables
-
 variable "vpc_cidr" {
   description = "The base CIDR that all subnets and vpcs will be created from. (Format 1.2.3.4/6)"
+}
+
+variable "public_subnets_list" {
+  type        = "list"
+  description = "A list of the subnets to create for public subnets"
+}
+
+variable "private_subnets_list" {
+  type        = "list"
+  description = "A list of the subnets to create for private subnets"
+}
+
+variable "admin_subnets_list" {
+  type        = "list"
+  description = "A list of the subnets to create for admin subnets"
 }
 
 variable "vpc_name" {
@@ -9,7 +23,7 @@ variable "vpc_name" {
 }
 
 variable "availability_zones" {
-  description = "The available zones, that matches the terraform provider you are using, for the VPC subnets and Nat Gateways. Format (us-west-2a,us-west-2b)"
+  description = "The available zones for the VPC subnets and NAT Gateways. Format (us-west-2a,us-west-2b). NOTE the counts for each subnet group and AZs listed MUST MATCH."
 }
 
 # Optional Variables
@@ -46,4 +60,30 @@ locals {
 
   tags             = "${merge(local.default_tags, var.extra_tags)}"
   avail_zones_list = "${split(",", var.availability_zones)}"
+}
+
+# Usage validation
+## NOTE: This is a hack for terraform to validate inputs to the module.
+##       The idea here is that you should always pass the same number of AZs
+##       into the module as the count of subnets. Otherwise you are using the
+##       module incorrectly. If you want three AZs, then you must pass in 3
+##       subnets for public, private and admin subnet areas.
+## The error for invalid usage is "Count is less than zero: -1"
+locals {
+  _count_of_availability_zones          = "${length(local.avail_zones_list)}"
+  _public_subnets_count_minus_az_count  = "${length(var.public_subnets_list) - local._count_of_availability_zones}"
+  _private_subnets_count_minus_az_count = "${length(var.private_subnets_list) - local._count_of_availability_zones}"
+  _admin_subnets_count_minus_az_count   = "${length(var.admin_subnets_list) - local._count_of_availability_zones}"
+}
+
+resource "null_resource" "validate_public_subnet_count_matches_availability_zone_count" {
+  count = "${local._public_subnets_count_minus_az_count == 0 ? 0 : -1}"
+}
+
+resource "null_resource" "validate_private_subnet_count_matches_availability_zone_count" {
+  count = "${local._private_subnets_count_minus_az_count == 0 ? 0 : -1}"
+}
+
+resource "null_resource" "validate_admin_subnet_count_matches_availability_zone_count" {
+  count = "${local._admin_subnets_count_minus_az_count == 0 ? 0 : -1}"
 }

--- a/modules/single-cluster/vpc.tf
+++ b/modules/single-cluster/vpc.tf
@@ -30,7 +30,7 @@ resource "aws_nat_gateway" "nat_gateway" {
   count         = "${local._count_of_availability_zones}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
   allocation_id = "${element(aws_eip.mod_nat.*.id, count.index)}"
-  tags          = "${local.tags}"
+  tags          = "${merge(local.tags, map("Name", "Kubernetes NAT Gateway"))}"
   depends_on    = ["aws_internet_gateway.default", "aws_eip.mod_nat", "aws_subnet.public"]
 
   lifecycle = {

--- a/modules/single-cluster/vpc.tf
+++ b/modules/single-cluster/vpc.tf
@@ -1,0 +1,90 @@
+# VPC
+resource "aws_vpc" "kube_vpc" {
+  cidr_block           = "${var.vpc_cidr}"
+  instance_tenancy     = "${var.vpc_instance_tenancy}"
+  enable_dns_support   = "${var.vpc_enable_dns_support}"
+  enable_dns_hostnames = "${var.vpc_enable_dns_hostnames}"
+  enable_classiclink   = "${var.vpc_enable_classiclink}"
+  tags                 = "${merge(local.tags, map("Name", "${var.vpc_name}"))}"
+
+  lifecycle = {
+    ignore_changes = ["tags"]
+  }
+}
+
+resource "aws_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.kube_vpc.id}"
+  tags   = "${merge(local.tags, map("Name", "${var.vpc_name}"))}"
+}
+
+output "aws_vpc_id" {
+  value = "${aws_vpc.kube_vpc.id}"
+}
+
+output "aws_vpc_cidr" {
+  value = "${aws_vpc.kube_vpc.cidr_block}"
+}
+
+# NAT Gateways & EIP
+resource "aws_nat_gateway" "nat_gateway" {
+  count         = 3
+  subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
+  allocation_id = "${element(aws_eip.mod_nat.*.id, count.index)}"
+  tags          = "${local.tags}"
+  depends_on    = ["aws_internet_gateway.default", "aws_eip.mod_nat", "aws_subnet.public"]
+
+  lifecycle = {
+    ignore_changes = ["tags"]
+  }
+}
+
+resource "aws_eip" "mod_nat" {
+  count = "${length(local.avail_zones_list)}"
+  tags  = "${local.tags}"
+  vpc   = true
+}
+
+output "aws_eip_nat_ips" {
+  value = ["${aws_eip.mod_nat.*.public_ip}"]
+}
+
+output "aws_nat_gateway_ids" {
+  value = ["${aws_nat_gateway.nat_gateway.*.id}"]
+}
+
+# Route Tables
+## Public
+resource "aws_route_table" "public" {
+  vpc_id = "${aws_vpc.kube_vpc.id}"
+  tags   = "${merge(local.tags, map("Name", "public"))}"
+}
+
+output "aws_route_table_public_ids" {
+  value = ["${aws_route_table.public.id}"]
+}
+
+resource "aws_route" "public_internet_gateway" {
+  route_table_id         = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.default.id}"
+}
+
+## Private
+resource "aws_route_table" "private" {
+  count  = 3
+  vpc_id = "${aws_vpc.kube_vpc.id}"
+
+  tags = "${merge(local.tags, map("Name", "private_az${(count.index +1)}"))}"
+}
+
+output "aws_route_table_private_ids" {
+  value = ["${aws_route_table.private.*.id}"]
+}
+
+resource "aws_route" "private_nat_gateway" {
+  count                  = 3
+  route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
+  nat_gateway_id         = "${element(aws_nat_gateway.nat_gateway.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  depends_on             = ["aws_route_table.private", "aws_nat_gateway.nat_gateway", "aws_vpc.kube_vpc"]
+}

--- a/modules/single-cluster/vpc.tf
+++ b/modules/single-cluster/vpc.tf
@@ -27,7 +27,7 @@ output "aws_vpc_cidr" {
 
 # NAT Gateways & EIP
 resource "aws_nat_gateway" "nat_gateway" {
-  count         = 3
+  count         = "${local._count_of_availability_zones}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
   allocation_id = "${element(aws_eip.mod_nat.*.id, count.index)}"
   tags          = "${local.tags}"
@@ -71,7 +71,7 @@ resource "aws_route" "public_internet_gateway" {
 
 ## Private
 resource "aws_route_table" "private" {
-  count  = 3
+  count  = "${local._count_of_availability_zones}"
   vpc_id = "${aws_vpc.kube_vpc.id}"
 
   tags = "${merge(local.tags, map("Name", "private_az${(count.index +1)}"))}"
@@ -82,7 +82,7 @@ output "aws_route_table_private_ids" {
 }
 
 resource "aws_route" "private_nat_gateway" {
-  count                  = 3
+  count                  = "${local._count_of_availability_zones}"
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   nat_gateway_id         = "${element(aws_nat_gateway.nat_gateway.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"


### PR DESCRIPTION
Things I'm trying to address in this PR:
- Current module doesn't support subnets other than `/16` without rewriting the module
- Environments should have separate VPCs (especially production and staging) so one cannot inadvertently affect the other
- Less configuration needed to use the module
- Still supporting the existing automation in pentagon

This module addresses the concerns above while keeping the output parameters used by the current pentagon automation for generating kops configs. It will create as many subnets as it needs with the CIDR input given and return the same set of subnets as the original module but with different sizes.

I would like to suggest we move to this when generating new inventories.

Things I am not addressing:
- A migration plan for people using the existing module